### PR TITLE
Update microsoft-identity-manager-2016-release-notes.md

### DIFF
--- a/MIMDocs/microsoft-identity-manager-2016-release-notes.md
+++ b/MIMDocs/microsoft-identity-manager-2016-release-notes.md
@@ -27,4 +27,4 @@ ms.suite: ems
 ---
 
 # Release Notes for MIM 2016
-No release notes at this time.
+The Microsoft Identity Manager team regularly releases updates. See the [MIM version release history](reference/version-history.md).


### PR DESCRIPTION
(435335)  I think the original MIM 2016 RTM release notes page is obsolete and needs to be replaced with a redirect.  IIRC we created https://docs.microsoft.com/en-us/microsoft-identity-manager/microsoft-identity-manager-2016-release-notes as a placeholder when we shipped MIM.  Currently it says “No release notes at this time”.   But that’s not right, we’ve done a service back and a bunch of hotfixes, and never updated that doc just created a new one instead.  Should that doc be replaced by a redirection to https://docs.microsoft.com/en-us/microsoft-identity-manager/reference/version-history which looks more like the release note for MIM?  Until then we should at least have a pointer from this document to that one.