### PR TITLE
Replace incorrect character in sample code

### DIFF
--- a/MIMDocs/preparing-domain.md
+++ b/MIMDocs/preparing-domain.md
@@ -50,38 +50,38 @@ All the components of your MIM deployment need their own identities in the domai
 
     ```
     import-module activedirectory
-    $sp = ConvertTo-SecureString "Pass@word1" –asplaintext –force
-    New-ADUser –SamAccountName MIMMA –name MIMMA
-    Set-ADAccountPassword –identity MIMMA –NewPassword $sp
-    Set-ADUser –identity MIMMA –Enabled 1 –PasswordNeverExpires 1
-    New-ADUser –SamAccountName MIMSync –name MIMSync
-    Set-ADAccountPassword –identity MIMSync –NewPassword $sp
-    Set-ADUser –identity MIMSync –Enabled 1 –PasswordNeverExpires 1
-    New-ADUser –SamAccountName MIMService –name MIMService
-    Set-ADAccountPassword –identity MIMService –NewPassword $sp
-    Set-ADUser –identity MIMService –Enabled 1 –PasswordNeverExpires 1
-    New-ADUser –SamAccountName MIMSSPR –name MIMSSPR
-    Set-ADAccountPassword –identity MIMSSPR –NewPassword $sp
-    Set-ADUser –identity MIMSSPR –Enabled 1 –PasswordNeverExpires 1
-    New-ADUser –SamAccountName SharePoint –name SharePoint
-    Set-ADAccountPassword –identity SharePoint –NewPassword $sp
-    Set-ADUser –identity SharePoint –Enabled 1 –PasswordNeverExpires 1
-    New-ADUser –SamAccountName SqlServer –name SqlServer
-    Set-ADAccountPassword –identity SqlServer –NewPassword $sp
-    Set-ADUser –identity SqlServer –Enabled 1 –PasswordNeverExpires 1
-    New-ADUser –SamAccountName BackupAdmin –name BackupAdmin
-    Set-ADAccountPassword –identity BackupAdmin –NewPassword $sp
-    Set-ADUser –identity BackupAdmin –Enabled 1 -PasswordNeverExpires 1
+    $sp = ConvertTo-SecureString "Pass@word1" -asplaintext -force
+    New-ADUser -SamAccountName MIMMA -name MIMMA
+    Set-ADAccountPassword -identity MIMMA -NewPassword $sp
+    Set-ADUser -identity MIMMA -Enabled 1 -PasswordNeverExpires 1
+    New-ADUser -SamAccountName MIMSync -name MIMSync
+    Set-ADAccountPassword -identity MIMSync -NewPassword $sp
+    Set-ADUser -identity MIMSync -Enabled 1 -PasswordNeverExpires 1
+    New-ADUser -SamAccountName MIMService -name MIMService
+    Set-ADAccountPassword -identity MIMService -NewPassword $sp
+    Set-ADUser -identity MIMService -Enabled 1 -PasswordNeverExpires 1
+    New-ADUser -SamAccountName MIMSSPR -name MIMSSPR
+    Set-ADAccountPassword -identity MIMSSPR -NewPassword $sp
+    Set-ADUser -identity MIMSSPR -Enabled 1 -PasswordNeverExpires 1
+    New-ADUser -SamAccountName SharePoint -name SharePoint
+    Set-ADAccountPassword -identity SharePoint -NewPassword $sp
+    Set-ADUser -identity SharePoint -Enabled 1 -PasswordNeverExpires 1
+    New-ADUser -SamAccountName SqlServer -name SqlServer
+    Set-ADAccountPassword -identity SqlServer -NewPassword $sp
+    Set-ADUser -identity SqlServer -Enabled 1 -PasswordNeverExpires 1
+    New-ADUser -SamAccountName BackupAdmin -name BackupAdmin
+    Set-ADAccountPassword -identity BackupAdmin -NewPassword $sp
+    Set-ADUser -identity BackupAdmin -Enabled 1 -PasswordNeverExpires 1
     ```
 
 3.  Create security groups to all the groups.
 
     ```
-    New-ADGroup –name MIMSyncAdmins –GroupCategory Security –GroupScope Global –SamAccountName MIMSyncAdmins
-    New-ADGroup –name MIMSyncOperators –GroupCategory Security –GroupScope Global –SamAccountName MIMSyncOperators
-    New-ADGroup –name MIMSyncJoiners –GroupCategory Security –GroupScope Global –SamAccountName MIMSyncJoiners
-    New-ADGroup –name MIMSyncBrowse –GroupCategory Security –GroupScope Global –SamAccountName MIMSyncBrowse
-    New-ADGroup –name MIMSyncPasswordReset –GroupCategory Security –GroupScope Global –SamAccountName MIMSyncPasswordReset
+    New-ADGroup -name MIMSyncAdmins -GroupCategory Security -GroupScope Global -SamAccountName MIMSyncAdmins
+    New-ADGroup -name MIMSyncOperators -GroupCategory Security -GroupScope Global -SamAccountName MIMSyncOperators
+    New-ADGroup -name MIMSyncJoiners -GroupCategory Security -GroupScope Global -SamAccountName MIMSyncJoiners
+    New-ADGroup -name MIMSyncBrowse -GroupCategory Security -GroupScope Global -SamAccountName MIMSyncBrowse
+    New-ADGroup -name MIMSyncPasswordReset -GroupCategory Security -GroupScope Global -SamAccountName MIMSyncPasswordReset
     Add-ADGroupMember -identity MIMSyncAdmins -Members Administrator
     Add-ADGroupmember -identity MIMSyncAdmins -Members MIMService
     ```


### PR DESCRIPTION
Fixes #173 
Your sample code contains "–", which looks like the correct one "-".
However, they're not the same character and they cause your sample code unable to run if you copy and paste them.
I created issue #173 almost one year ago and no one is fixing them.